### PR TITLE
Always use left-to-right for user input

### DIFF
--- a/app/src/main/res/layout/fragment_solve_puzzle.xml
+++ b/app/src/main/res/layout/fragment_solve_puzzle.xml
@@ -55,6 +55,7 @@
                 android:layout_weight="1"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
+                android:textDirection="ltr"
                 android:hint="@string/user_answer_hint" />
             <Button android:id="@+id/submit_answer"
                 android:layout_width="wrap_content"


### PR DESCRIPTION
The input consists only of mathematical symbols, not of natural language
text.

Previously, using the app in a right-to-left language, such as Hebrew or
Arabic, started the input on the right-hand side of the input field, and
typing a '(' was shown as ')'.

Mentioned in https://github.com/atorch/probability_puzzles/issues/20.