### PR TITLE
feat: Add "Talk to Gemini" hint option

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -49,4 +49,5 @@ jobs:
           api-level: 33
           arch: x86_64
           emulator-options: "-no-window -no-snapshot -prop persist.sys.language=${{ steps.locale_props.outputs.language }} -prop persist.sys.country=${{ steps.locale_props.outputs.country }}"
+          device: "pixel_6"
           script: ./gradlew connectedAndroidTest

--- a/README.md
+++ b/README.md
@@ -156,3 +156,109 @@ Wait for the emulator to boot up, and then run the tests:
     ```bash
     adb emu kill
     ```
+
+## Running the App on a Physical Device
+
+You can also install and run the app on a physical Android device using the command line.
+
+### 1. Enable USB Debugging on Your Device
+
+1.  On your Android device, open **Settings**.
+2.  Go to **About phone**.
+3.  Tap **Build number** seven times to enable **Developer options**.
+4.  Go back to the main **Settings** menu, then go to **System** > **Developer options**.
+5.  Enable **USB debugging**.
+
+### 2. Connect Your Device via USB
+
+Connect your Android device to your computer using a USB cable. A prompt might appear on your device asking you to authorize the computer for debugging. Accept it.
+
+### 3. Build and Install the App
+
+1.  **Navigate to the project directory:**
+    ```bash
+    cd /home/adrian/probability_puzzles
+    ```
+
+2.  **Build the debug APK:**
+    ```bash
+    ./gradlew assembleDebug
+    ```
+    Note: Gradle uses an incremental build process. If you haven't made any code changes, Gradle may not rebuild the APK. To force a rebuild, you can run `./gradlew clean assembleDebug`.
+
+3.  **Install the APK on your device:**
+    ```bash
+    adb install -r app/build/outputs/apk/debug/app-debug.apk
+    ```
+
+The `-r` flag reinstalls the app, keeping its data. After the command completes, the app will be installed on your device, and you can run it by tapping its icon.
+
+## Running the App on a Physical Device (Wireless Debugging)
+
+You can also connect to your device wirelessly. This is especially useful if you have issues with USB drivers or cables.
+
+### 1. Enable Wireless Debugging
+
+1.  On your Android device, open **Settings** > **System** > **Developer options**.
+2.  Enable **Wireless debugging**.
+3.  Make sure your device and your computer are on the same Wi-Fi network.
+
+### 2. Pair Your Device
+
+You only need to pair your device once.
+
+**Option A: Pairing with QR Code (Recommended)**
+
+1.  In Android Studio, go to the **Device Manager** and select **Pair devices using Wi-Fi**.
+2.  A QR code will be displayed.
+3.  On your device, under **Wireless debugging**, select **Pair device with QR code** and scan the QR code on your computer.
+
+**Option B: Pairing with Command Line**
+
+1.  On your device, under **Wireless debugging**, select **Pair device with pairing code**.
+2.  You will see a pairing code and an IP address with a port (e.g., `192.168.1.100:41234`).
+3.  On your computer, run the following command, replacing the IP, port, and pairing code with the ones from your device:
+    ```bash
+    adb pair 192.168.1.100:41234 123456
+    ```
+
+### 3. Connect to Your Device
+
+After pairing, you need to connect to your device.
+
+1.  On your device, under **Wireless debugging**, you will see an IP address and port for the connection (e.g., `192.168.1.100:38765`). This port is different from the pairing port.
+2.  On your computer, run the following command, replacing the IP and port with the ones from your device:
+    ```bash
+    adb connect 192.168.1.100:38765
+    ```
+3.  You can verify the connection by running `adb devices`. You should see your device listed.
+
+### 4. Troubleshooting Wireless Debugging
+
+Wireless debugging can sometimes be tricky. Here are some common issues and how to solve them:
+
+*   **`adb devices` shows `offline`:**
+    *   On your device, go to **Settings** > **System** > **Developer options** and tap **Revoke USB debugging authorizations**.
+    *   Toggle **Wireless debugging** off and on again.
+    *   Reconnect to your device.
+
+*   **`adb pair` fails with `protocol fault`:**
+    *   This can be a network issue. Make sure you are not on a VPN.
+    *   Check if your firewall is blocking the connection.
+    *   Some routers have an "AP Isolation" feature that prevents devices from communicating. Make sure it's disabled.
+    *   Restart the ADB server with `adb kill-server`.
+
+*   **Build fails with `IOException: Unable to delete directory`:**
+    *   This is likely a file ownership issue caused by running Android Studio with `sudo`. **Do not run Android Studio with `sudo`!**
+    *   To fix this, you need to change the ownership of the project files back to your user. Run the following command, replacing `your_user` with your username:
+        ```bash
+        sudo chown -R your_user:your_user /path/to/your/project
+        ```
+    *   You might also need to stop the Gradle daemon with `./gradlew --stop`.
+
+*   **Installation fails with `INSTALL_FAILED_UPDATE_INCOMPATIBLE`:**
+    *   This means the app is already installed with a different signature (e.g., from the Play Store).
+    *   Uninstall the app from your device and try again. You can do this from the command line:
+        ```bash
+        adb uninstall atorch.statspuzzles
+        ```

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ sudo apt-get install -y openjdk-17-jdk
     ```bash
     avdmanager create avd -n pixel_33 -k "system-images;android-33;default;x86_64" --device "pixel_6"
     ```
-    This creates an AVD named `pixel_33` using the Pixel 6 device profile.
+    This creates an AVD named `pixel_33` using the `"pixel_6"` device profile, which simulates the screen size and characteristics of a Google Pixel 6 phone. The GitHub Actions CI is configured to use the same device profile to ensure that tests run in a consistent environment.
 
 ### 5. Run the Tests
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,25 @@ sudo apt-get install -y openjdk-17-jdk
     ```
     The Gradle script will automatically detect the running emulator and execute the tests on it.
 
-3.  **Shut down the emulator when you're done:**
+### 6. Running Tests for a Different Locale
+
+To reproduce the CI environment for a specific locale, you need to start the emulator with the desired language settings. The CI runs tests against English, German, Spanish, and Arabic.
+
+First, make sure the emulator is not running (`adb emu kill`).
+
+Then, start the emulator with the desired locale. For example, to start the emulator with the German locale, run:
+
+```bash
+emulator -avd pixel_33 -no-window -prop persist.sys.language=de -prop persist.sys.country=DE &
+```
+
+Wait for the emulator to boot up, and then run the tests:
+
+```bash
+./gradlew connectedAndroidTest
+```
+
+### 7. Shut down the emulator when you're done:
     ```bash
     adb emu kill
     ```

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     implementation 'androidx.navigation:navigation-ui:2.5.3'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
-        androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
     androidTestImplementation 'androidx.test.espresso:espresso-intents:3.6.1'
     implementation fileTree(dir: 'libs', include: ['*.aar', '*.jar'], exclude: [])
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.7.10"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,7 +5,7 @@ android {
 
     defaultConfig {
         applicationId "atorch.statspuzzles"
-        minSdkVersion 16
+        minSdkVersion 19
         targetSdkVersion 34
         versionCode 32
         versionName "4.0"
@@ -37,7 +37,8 @@ dependencies {
     implementation 'androidx.navigation:navigation-ui:2.5.3'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+        androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-intents:3.6.1'
     implementation fileTree(dir: 'libs', include: ['*.aar', '*.jar'], exclude: [])
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.7.10"
 }

--- a/app/src/androidTest/java/atorch/statspuzzles/SolvePuzzleTest.java
+++ b/app/src/androidTest/java/atorch/statspuzzles/SolvePuzzleTest.java
@@ -47,9 +47,12 @@ public class SolvePuzzleTest {
         // fragment, as multiple fragments can exist in a ViewPager2.
         Espresso.onView(allOf(withId(R.id.button_gemini_hint), isDisplayed())).perform(scrollTo(), click());
 
+        // This tests the logic in SolvePuzzle's showGeminiHint, which tries to open the Gemini app
+        // directly if it's installed, and otherwise falls back to the Play Store.
+        // The test framework doesn't have Gemini installed, so it should always go to the Play Store.
         intended(allOf(
                 hasAction(Intent.ACTION_VIEW),
-                hasData("market://details?id=com.google.android.apps.gemini")
+                hasData("market://details?id=com.google.android.apps.bard")
         ));
     }
 }

--- a/app/src/androidTest/java/atorch/statspuzzles/SolvePuzzleTest.java
+++ b/app/src/androidTest/java/atorch/statspuzzles/SolvePuzzleTest.java
@@ -1,0 +1,50 @@
+package atorch.statspuzzles;
+
+import android.content.Context;
+import android.content.Intent;
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.espresso.Espresso;
+import androidx.test.espresso.intent.Intents;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.intent.Intents.intended;
+import static androidx.test.espresso.intent.matcher.IntentMatchers.hasAction;
+import static androidx.test.espresso.intent.matcher.IntentMatchers.hasData;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static org.hamcrest.CoreMatchers.allOf;
+
+@RunWith(AndroidJUnit4.class)
+public class SolvePuzzleTest {
+
+    @Before
+    public void setUp() {
+        Intents.init();
+    }
+
+    @After
+    public void tearDown() {
+        Intents.release();
+    }
+
+    @Test
+    public void geminiButton_launchesPlayStore() {
+        Context context = ApplicationProvider.getApplicationContext();
+        Intent intent = new Intent(context, SolvePuzzle.class);
+        intent.putExtra(SolvePuzzle.LEVEL, 0);
+        ActivityScenario.launch(intent);
+
+        Espresso.onView(withId(R.id.button_gemini_hint)).perform(click());
+
+        intended(allOf(
+                hasAction(Intent.ACTION_VIEW),
+                hasData("market://details?id=com.google.android.apps.gemini")
+        ));
+    }
+}

--- a/app/src/androidTest/java/atorch/statspuzzles/SolvePuzzleTest.java
+++ b/app/src/androidTest/java/atorch/statspuzzles/SolvePuzzleTest.java
@@ -17,6 +17,7 @@ import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.intent.Intents.intended;
 import static androidx.test.espresso.intent.matcher.IntentMatchers.hasAction;
 import static androidx.test.espresso.intent.matcher.IntentMatchers.hasData;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static org.hamcrest.CoreMatchers.allOf;
 

--- a/app/src/androidTest/java/atorch/statspuzzles/SolvePuzzleTest.java
+++ b/app/src/androidTest/java/atorch/statspuzzles/SolvePuzzleTest.java
@@ -40,7 +40,9 @@ public class SolvePuzzleTest {
         intent.putExtra(SolvePuzzle.LEVEL, 0);
         ActivityScenario.launch(intent);
 
-        Espresso.onView(withId(R.id.button_gemini_hint)).perform(click());
+        // In a ViewPager2, multiple fragments can be in the view hierarchy.
+        // isDisplayed() ensures we're clicking the button on the current, visible fragment.
+        Espresso.onView(allOf(withId(R.id.button_gemini_hint), isDisplayed())).perform(click());
 
         intended(allOf(
                 hasAction(Intent.ACTION_VIEW),

--- a/app/src/androidTest/java/atorch/statspuzzles/SolvePuzzleTest.java
+++ b/app/src/androidTest/java/atorch/statspuzzles/SolvePuzzleTest.java
@@ -14,6 +14,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.action.ViewActions.scrollTo;
 import static androidx.test.espresso.intent.Intents.intended;
 import static androidx.test.espresso.intent.matcher.IntentMatchers.hasAction;
 import static androidx.test.espresso.intent.matcher.IntentMatchers.hasData;
@@ -41,9 +42,10 @@ public class SolvePuzzleTest {
         intent.putExtra(SolvePuzzle.LEVEL, 0);
         ActivityScenario.launch(intent);
 
-        // In a ViewPager2, multiple fragments can be in the view hierarchy.
-        // isDisplayed() ensures we're clicking the button on the current, visible fragment.
-        Espresso.onView(allOf(withId(R.id.button_gemini_hint), isDisplayed())).perform(click());
+        // On smaller screens, the button might be off-screen, so we scroll to it first.
+        // isDisplayed() is still needed to ensure we click the button in the currently visible
+        // fragment, as multiple fragments can exist in a ViewPager2.
+        Espresso.onView(allOf(withId(R.id.button_gemini_hint), isDisplayed())).perform(scrollTo(), click());
 
         intended(allOf(
                 hasAction(Intent.ACTION_VIEW),

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <queries>
+        <package android:name="com.google.android.apps.bard" />
+    </queries>
+
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"

--- a/app/src/main/java/atorch/statspuzzles/SolvePuzzle.java
+++ b/app/src/main/java/atorch/statspuzzles/SolvePuzzle.java
@@ -253,6 +253,7 @@ public class SolvePuzzle extends AppCompatActivity {
         @Override
         public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
             View rootView = inflater.inflate(R.layout.fragment_solve_puzzle, container, false);
+            final FragmentActivity activity = requireActivity();
             res = new Res(getResources());
 
             Bundle args = getArguments();
@@ -287,7 +288,7 @@ public class SolvePuzzle extends AppCompatActivity {
             String answer = res.getAnswer(level, puzzleIndex);
 
             EditText user_answer = rootView.findViewById(R.id.user_answer);
-            SharedPreferences preferences = getActivity().getSharedPreferences("atorch.statspuzzles.data", Context.MODE_PRIVATE);
+            SharedPreferences preferences = activity.getSharedPreferences("atorch.statspuzzles.data", Context.MODE_PRIVATE);
             String key = level + "_" + puzzleIndex;
             boolean already_solved_this_puzzle = preferences.getBoolean(key, false);
             if (already_solved_this_puzzle) {
@@ -304,7 +305,7 @@ public class SolvePuzzle extends AppCompatActivity {
             }
 
             // Add image below puzzle statement
-            String packageName = getActivity().getPackageName();
+            String packageName = activity.getPackageName();
             String image = res.getImage(level, puzzleIndex);
             if (!image.isEmpty()) {
                 ImageView imageView = rootView.findViewById(R.id.puzzleImage);
@@ -319,7 +320,7 @@ public class SolvePuzzle extends AppCompatActivity {
             SpannableString hintSpannable = new SpannableString(hint); // msg should have url to enable clicking
             Linkify.addLinks(hintSpannable, Linkify.ALL);
 
-            AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+            AlertDialog.Builder builder = new AlertDialog.Builder(requireActivity());
             builder.setMessage(hintSpannable);
             builder.setCancelable(true);
             builder.setPositiveButton(R.string.button_back_to_puzzle,
@@ -333,6 +334,7 @@ public class SolvePuzzle extends AppCompatActivity {
         }
 
         private void onGeminiHint() {
+            final FragmentActivity activity = requireActivity();
             String puzzleText = res.getPuzzle(level, puzzleIndex);
             String prompt = getString(R.string.gemini_prompt_template) + puzzleText;
 
@@ -341,26 +343,26 @@ public class SolvePuzzle extends AppCompatActivity {
             // more context-aware hint.
             // For example:
             // String hint = res.getHint(level, puzzleIndex);
-            // String prompt = getString(R.string.gemini_prompt_template) + puzzleText +
+            // String prompt = getString(R.string.gemini_prompt_template) + puzzleText + 
             //         "\n\nHere's the current hint, please expand on it: " + hint;
 
-            ClipboardManager clipboard = (ClipboardManager) getActivity().getSystemService(Context.CLIPBOARD_SERVICE);
+            ClipboardManager clipboard = (ClipboardManager) activity.getSystemService(Context.CLIPBOARD_SERVICE);
             ClipData clip = ClipData.newPlainText("puzzle", prompt);
             clipboard.setPrimaryClip(clip);
 
-            Toast.makeText(getActivity(), R.string.puzzle_copied_to_clipboard, Toast.LENGTH_SHORT).show();
+            Toast.makeText(activity, R.string.puzzle_copied_to_clipboard, Toast.LENGTH_SHORT).show();
 
             String geminiPackageName = "com.google.android.apps.gemini";
-            PackageManager pm = getActivity().getPackageManager();
+            PackageManager pm = activity.getPackageManager();
             Intent intent = pm.getLaunchIntentForPackage(geminiPackageName);
             if (intent != null) {
-                getActivity().startActivity(intent);
+                activity.startActivity(intent);
             } else {
-                Toast.makeText(getActivity(), R.string.gemini_not_installed, Toast.LENGTH_SHORT).show();
+                Toast.makeText(activity, R.string.gemini_not_installed, Toast.LENGTH_SHORT).show();
                 try {
-                    getActivity().startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse("market://details?id=" + geminiPackageName)));
+                    activity.startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse("market://details?id=" + geminiPackageName)));
                 } catch (android.content.ActivityNotFoundException anfe) {
-                    getActivity().startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse("https://play.google.com/store/apps/details?id=" + geminiPackageName)));
+                    activity.startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse("https://play.google.com/store/apps/details?id=" + geminiPackageName)));
                 }
             }
         }
@@ -399,7 +401,7 @@ public class SolvePuzzle extends AppCompatActivity {
         }
 
         public void openTroubleParsingDialog(View view) {
-            AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+            AlertDialog.Builder builder = new AlertDialog.Builder(requireActivity());
             builder.setMessage(getString(R.string.trouble_parsing_answer));
             builder.setCancelable(true);
             builder.setPositiveButton(R.string.okay_button,
@@ -410,9 +412,10 @@ public class SolvePuzzle extends AppCompatActivity {
         }
 
         public void openCongratulationsAlert(View view) {
+            final FragmentActivity activity = requireActivity();
             ImageView checkmark = getView().findViewById(R.id.check_mark);
             checkmark.setVisibility(View.VISIBLE);
-            SharedPreferences preferences = getActivity().getSharedPreferences("atorch.statspuzzles.data", Context.MODE_PRIVATE);
+            SharedPreferences preferences = activity.getSharedPreferences("atorch.statspuzzles.data", Context.MODE_PRIVATE);
             SharedPreferences.Editor editor = preferences.edit();
             String key = level + "_" + puzzleIndex;
             boolean already_solved_this_puzzle = preferences.getBoolean(key, false);
@@ -435,7 +438,7 @@ public class SolvePuzzle extends AppCompatActivity {
             editor.putBoolean(key, true);
             editor.commit();
 
-            AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+            AlertDialog.Builder builder = new AlertDialog.Builder(activity);
             ViewPager2 viewPager = view.getRootView().findViewById(R.id.pager);
 
             int nPuzzles = res.getPuzzleCount(level);
@@ -455,7 +458,7 @@ public class SolvePuzzle extends AppCompatActivity {
                 );
                 builder.setNegativeButton(R.string.main_menu_button,
                         (dialog, id) -> {
-                            Intent intent = new Intent(getActivity(), PuzzleSelection.class);
+                            Intent intent = new Intent(activity, PuzzleSelection.class);
                             startActivity(intent);
                         }
                 );
@@ -468,7 +471,7 @@ public class SolvePuzzle extends AppCompatActivity {
                 builder.setCancelable(true);
                 builder.setPositiveButton(R.string.main_menu_button,
                         (dialog, id) -> {
-                            Intent intent = new Intent(getActivity(), PuzzleSelection.class);
+                            Intent intent = new Intent(activity, PuzzleSelection.class);
                             startActivity(intent);
                         }
                 );
@@ -482,12 +485,12 @@ public class SolvePuzzle extends AppCompatActivity {
         }
 
         public void openIncorrectAnswerToast() {
-            Context context = getActivity();
+            Context context = requireActivity();
             Toast.makeText(context, res.getRandomIncorrect(), Toast.LENGTH_LONG).show();
         }
 
         public void openAccuracyAlert(View view) {
-            AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+            AlertDialog.Builder builder = new AlertDialog.Builder(requireActivity());
             builder.setMessage(getString(R.string.accuracy));
             builder.setCancelable(true);
             builder.setPositiveButton(R.string.ok_button,
@@ -500,7 +503,7 @@ public class SolvePuzzle extends AppCompatActivity {
         public void hideSoftKeyboard() {
             View editBox = getView().findViewById(R.id.user_answer);
             editBox.clearFocus();
-            InputMethodManager IMM = (InputMethodManager) getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
+            InputMethodManager IMM = (InputMethodManager) requireContext().getSystemService(Context.INPUT_METHOD_SERVICE);
             IMM.hideSoftInputFromWindow(editBox.getWindowToken(), 0);
         }
 

--- a/app/src/main/java/atorch/statspuzzles/SolvePuzzle.java
+++ b/app/src/main/java/atorch/statspuzzles/SolvePuzzle.java
@@ -249,7 +249,6 @@ public class SolvePuzzle extends AppCompatActivity {
         private int level;
         private int puzzleIndex;
         private Res res;
-        private Button geminiHintButton;
 
         @Override
         public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
@@ -279,7 +278,7 @@ public class SolvePuzzle extends AppCompatActivity {
             hintButton.setVisibility(View.VISIBLE);
             hintButton.setOnClickListener(unused -> showHint());
 
-            geminiHintButton = rootView.findViewById(R.id.button_gemini_hint);
+            Button geminiHintButton = rootView.findViewById(R.id.button_gemini_hint);
             geminiHintButton.setOnClickListener(v -> onGeminiHint());
 
             Button submitButton = rootView.findViewById(R.id.submit_answer);
@@ -496,27 +495,6 @@ public class SolvePuzzle extends AppCompatActivity {
             );
             AlertDialog alert = builder.create();
             alert.show();
-        }
-
-        // The user might be swiping between puzzles. The ViewPager2 keeps off-screen fragments
-        // in the view hierarchy. We need to make sure the button is only visible on the current
-        // puzzle, otherwise Espresso tests might find multiple buttons with the same ID and fail
-        // with an AmbiguousViewMatcherException.
-        @Override
-        public void onResume() {
-            super.onResume();
-            if (geminiHintButton != null) {
-                geminiHintButton.setVisibility(View.VISIBLE);
-            }
-        }
-
-        @Override
-        public void onPause() {
-            hideSoftKeyboard();
-            if (geminiHintButton != null) {
-                geminiHintButton.setVisibility(View.INVISIBLE);
-            }
-            super.onPause();
         }
 
         public void hideSoftKeyboard() {

--- a/app/src/main/java/atorch/statspuzzles/SolvePuzzle.java
+++ b/app/src/main/java/atorch/statspuzzles/SolvePuzzle.java
@@ -30,6 +30,7 @@ import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.ShareActionProvider;
 import androidx.core.view.MenuItemCompat;
+
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
 import androidx.fragment.app.FragmentManager;
@@ -336,29 +337,26 @@ public class SolvePuzzle extends AppCompatActivity {
         private void onGeminiHint() {
             final FragmentActivity activity = requireActivity();
             String puzzleText = res.getPuzzle(level, puzzleIndex);
-            String prompt = getString(R.string.gemini_prompt_template) + puzzleText;
+            String hint = res.getHint(level, puzzleIndex);
+            String prompt = getString(R.string.gemini_prompt_template) + " " + puzzleText +
+                    "\n\n" + getString(R.string.gemini_expand_hint) + " " + hint;
 
-            // TODO: Consider including the existing hint string in the prompt to Gemini,
-            // asking it to expand on that hint. This might help the bot provide a better,
-            // more context-aware hint.
-            // For example:
-            // String hint = res.getHint(level, puzzleIndex);
-            // String prompt = getString(R.string.gemini_prompt_template) + puzzleText + 
-            //         "\n\nHere's the current hint, please expand on it: " + hint;
-
+            // Copy to clipboard
             ClipboardManager clipboard = (ClipboardManager) activity.getSystemService(Context.CLIPBOARD_SERVICE);
             ClipData clip = ClipData.newPlainText("puzzle", prompt);
             clipboard.setPrimaryClip(clip);
-
             Toast.makeText(activity, R.string.puzzle_copied_to_clipboard, Toast.LENGTH_SHORT).show();
 
-            String geminiPackageName = "com.google.android.apps.gemini";
+            // The package name for the Google Gemini app is com.google.android.apps.bard.
+            String geminiPackageName = "com.google.android.apps.bard";
             PackageManager pm = activity.getPackageManager();
             Intent intent = pm.getLaunchIntentForPackage(geminiPackageName);
+
             if (intent != null) {
+                // The Gemini app is installed. Launch it.
                 activity.startActivity(intent);
             } else {
-                Toast.makeText(activity, R.string.gemini_not_installed, Toast.LENGTH_SHORT).show();
+                // If the Gemini app is not installed, open the Play Store.
                 try {
                     activity.startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse("market://details?id=" + geminiPackageName)));
                 } catch (android.content.ActivityNotFoundException anfe) {

--- a/app/src/main/res/layout/fragment_solve_puzzle.xml
+++ b/app/src/main/res/layout/fragment_solve_puzzle.xml
@@ -1,7 +1,8 @@
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    tools:context="atorch.statspuzzles.PuzzleSelection" >
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -9,8 +10,7 @@
         android:paddingBottom="@dimen/activity_vertical_margin"
         android:paddingStart="@dimen/activity_horizontal_margin"
         android:paddingEnd="@dimen/activity_horizontal_margin"
-        android:paddingTop="@dimen/activity_vertical_margin_half"
-        tools:context="atorch.statspuzzles.PuzzleSelection" >
+        android:paddingTop="@dimen/activity_vertical_margin_half" >
 
         <TextView
             android:layout_marginTop="@dimen/activity_vertical_margin_half"

--- a/app/src/main/res/layout/fragment_solve_puzzle.xml
+++ b/app/src/main/res/layout/fragment_solve_puzzle.xml
@@ -100,6 +100,16 @@
             android:textAlignment="center"
             android:text="@string/button_hint" />
 
+        <Button android:gravity="center_horizontal"
+            style="?android:attr/borderlessButtonStyle"
+            android:layout_marginTop="@dimen/activity_vertical_margin"
+            android:id="@+id/button_gemini_hint"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textStyle="bold"
+            android:textAlignment="center"
+            android:text="@string/button_gemini_hint" />
+
         <TextView
             android:layout_marginTop="@dimen/activity_vertical_margin_double"
             android:gravity="center_horizontal"

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -56,7 +56,7 @@
     <string name="button_hint">تحتاج تلميحاً؟</string>
     <string name="button_gemini_hint">التحدث إلى Gemini</string>
     <string name="puzzle_copied_to_clipboard">تم نسخ اللغز إلى الحافظة.</string>
-    <string name="gemini_not_installed">تطبيق Gemini غير مثبت. جارٍ فتح متجر Play.</string>
+    <string name="gemini_not_installed">تطبيق Gemini غير مثبت. جارٍ فتح Google Play.</string>
 
     <string-array name="levelDescriptions">
         <item>المستوى: سهل جداً — أنت تقوم بالإحماء فقط.</item>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -54,9 +54,9 @@
     <string name="button_level_1">المستوى المتقدم</string>
     <string name="button_level_2">المستوى الفظيع</string>
     <string name="button_hint">تحتاج تلميحاً؟</string>
-    <string name="button_gemini_hint">Talk to Gemini</string>
-    <string name="puzzle_copied_to_clipboard">Puzzle copied to clipboard.</string>
-    <string name="gemini_not_installed">Gemini app not installed. Opening Play Store.</string>
+    <string name="button_gemini_hint">التحدث إلى Gemini</string>
+    <string name="puzzle_copied_to_clipboard">تم نسخ اللغز إلى الحافظة.</string>
+    <string name="gemini_not_installed">تطبيق Gemini غير مثبت. جارٍ فتح متجر Play.</string>
 
     <string-array name="levelDescriptions">
         <item>المستوى: سهل جداً — أنت تقوم بالإحماء فقط.</item>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -617,5 +617,6 @@
         <item>1/42</item>
         <item>40/100</item>
     </string-array>
+    <string name="gemini_prompt_template">هل يمكنك أن تعطيني تلميحًا لهذا اللغز، دون الكشف عن الإجابة؟ إليك اللغز: </string>
 </resources>
 

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -54,6 +54,9 @@
     <string name="button_level_1">المستوى المتقدم</string>
     <string name="button_level_2">المستوى الفظيع</string>
     <string name="button_hint">تحتاج تلميحاً؟</string>
+    <string name="button_gemini_hint">Talk to Gemini</string>
+    <string name="puzzle_copied_to_clipboard">Puzzle copied to clipboard.</string>
+    <string name="gemini_not_installed">Gemini app not installed. Opening Play Store.</string>
 
     <string-array name="levelDescriptions">
         <item>المستوى: سهل جداً — أنت تقوم بالإحماء فقط.</item>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -617,6 +617,7 @@
         <item>1/42</item>
         <item>40/100</item>
     </string-array>
-    <string name="gemini_prompt_template">هل يمكنك أن تعطيني تلميحًا لهذا اللغز، دون الكشف عن الإجابة؟ إليك اللغز: </string>
+        <string name="gemini_prompt_template">هل يمكنك أن تعطيني تلميحًا لهذا اللغز، دون الكشف عن الإجابة؟ إليك اللغز: </string>
+    <string name="gemini_expand_hint">هذه هي التلميحة الحالية، يرجى التوسع فيها:</string>
 </resources>
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -565,5 +565,6 @@
         <item>40/100</item>
     </string-array>
 
-    <string name="gemini_prompt_template">Können Sie mir einen Hinweis zu diesem Rätsel geben, ohne die Antwort zu verraten? Hier ist das Rätsel: </string>
+        <string name="gemini_prompt_template">Können Sie mir einen Hinweis zu diesem Rätsel geben, ohne die Antwort zu verraten? Hier ist das Rätsel: </string>
+    <string name="gemini_expand_hint">Hier ist der aktuelle Hinweis, bitte erweitern Sie ihn:</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -51,9 +51,9 @@
     <string name="button_level_1">Jetzt wird’s ernst</string>
     <string name="button_level_2">Knifflig</string>
     <string name="button_hint">Brauchst du einen Tipp?</string>
-    <string name="button_gemini_hint">Talk to Gemini</string>
-    <string name="puzzle_copied_to_clipboard">Puzzle copied to clipboard.</string>
-    <string name="gemini_not_installed">Gemini app not installed. Opening Play Store.</string>
+    <string name="button_gemini_hint">Mit Gemini sprechen</string>
+    <string name="puzzle_copied_to_clipboard">Rätsel in die Zwischenablage kopiert.</string>
+    <string name="gemini_not_installed">Gemini-App nicht installiert. Play Store wird geöffnet.</string>
 
     <string-array name="levelDescriptions">
         <item>Level: kinderleicht\u00A0– nur so zum Aufwärmen.</item>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -51,6 +51,9 @@
     <string name="button_level_1">Jetzt wird’s ernst</string>
     <string name="button_level_2">Knifflig</string>
     <string name="button_hint">Brauchst du einen Tipp?</string>
+    <string name="button_gemini_hint">Talk to Gemini</string>
+    <string name="puzzle_copied_to_clipboard">Puzzle copied to clipboard.</string>
+    <string name="gemini_not_installed">Gemini app not installed. Opening Play Store.</string>
 
     <string-array name="levelDescriptions">
         <item>Level: kinderleicht\u00A0– nur so zum Aufwärmen.</item>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -565,4 +565,5 @@
         <item>40/100</item>
     </string-array>
 
+    <string name="gemini_prompt_template">Können Sie mir einen Hinweis zu diesem Rätsel geben, ohne die Antwort zu verraten? Hier ist das Rätsel: </string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -54,6 +54,9 @@
     <string name="button_level_1">Poniéndonos serios</string>
     <string name="button_level_2">Escandalosos</string>
     <string name="button_hint">¿Necesitas una pista?</string>
+    <string name="button_gemini_hint">Talk to Gemini</string>
+    <string name="puzzle_copied_to_clipboard">Puzzle copied to clipboard.</string>
+    <string name="gemini_not_installed">Gemini app not installed. Opening Play Store.</string>
 
     <string-array name="levelDescriptions">
         <item>Nivel: sencillitos &#8212; solo estás calentando.</item>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -54,7 +54,7 @@
     <string name="button_level_1">Poniéndonos serios</string>
     <string name="button_level_2">Escandalosos</string>
     <string name="button_hint">¿Necesitas una pista?</string>
-    <string name="button_gemini_hint">Talk to Gemini</string>
+    <string name="button_gemini_hint">Hablar con Gemini</string>
     <string name="puzzle_copied_to_clipboard">Puzzle copied to clipboard.</string>
     <string name="gemini_not_installed">Gemini app not installed. Opening Play Store.</string>
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -55,8 +55,8 @@
     <string name="button_level_2">Escandalosos</string>
     <string name="button_hint">¿Necesitas una pista?</string>
     <string name="button_gemini_hint">Hablar con Gemini</string>
-    <string name="puzzle_copied_to_clipboard">Puzzle copied to clipboard.</string>
-    <string name="gemini_not_installed">Gemini app not installed. Opening Play Store.</string>
+    <string name="puzzle_copied_to_clipboard">Acertijo copiado al portapapeles.</string>
+    <string name="gemini_not_installed">La aplicación Gemini no está instalada. Abriendo Play Store.</string>
 
     <string-array name="levelDescriptions">
         <item>Nivel: sencillitos &#8212; solo estás calentando.</item>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -704,5 +704,6 @@
     </string-array>
 
 
-    <string name="gemini_prompt_template">¿Puedes darme una pista para este rompecabezas, sin revelar la respuesta? Aquí está el rompecabezas: </string>
+        <string name="gemini_prompt_template">¿Puedes darme una pista para este rompecabezas, sin revelar la respuesta? Aquí está el rompecabezas: </string>
+    <string name="gemini_expand_hint">Aquí está la pista actual, por favor amplíala:</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -704,4 +704,5 @@
     </string-array>
 
 
+    <string name="gemini_prompt_template">¿Puedes darme una pista para este rompecabezas, sin revelar la respuesta? Aquí está el rompecabezas: </string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -705,4 +705,5 @@
     </string-array>
 
 
+    <string name="gemini_prompt_template">Can you give me a hint for this puzzle, without giving away the answer? Here\'s the puzzle: </string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -54,6 +54,9 @@
     <string name="button_level_1">Getting Serious</string>
     <string name="button_level_2">Outrageous</string>
     <string name="button_hint">Need a hint?</string>
+    <string name="button_gemini_hint">Talk to Gemini</string>
+    <string name="puzzle_copied_to_clipboard">Puzzle copied to clipboard.</string>
+    <string name="gemini_not_installed">Gemini app not installed. Opening Play Store.</string>
 
     <string-array name="levelDescriptions">
         <item>Level: easy peasy &#8212; you\'re just warming up.</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -706,4 +706,5 @@
 
 
     <string name="gemini_prompt_template">Can you give me a hint for this puzzle, without giving away the answer? Here\'s the puzzle: </string>
+    <string name="gemini_expand_hint">Here\'s the current hint, please expand on it:</string>
 </resources>

--- a/app/src/test/java/atorch/statspuzzles/AnswerCheckerTest.java
+++ b/app/src/test/java/atorch/statspuzzles/AnswerCheckerTest.java
@@ -10,6 +10,7 @@ public class AnswerCheckerTest {
         assertEquals(AnswerChecker.Result.CORRECT, AnswerChecker.checkAnswer("2+2", "4"));
         assertEquals(AnswerChecker.Result.CORRECT, AnswerChecker.checkAnswer("1/2", "0.5"));
         assertEquals(AnswerChecker.Result.CORRECT, AnswerChecker.checkAnswer("3!", "6.0"));
+        assertEquals(AnswerChecker.Result.CORRECT, AnswerChecker.checkAnswer("1/(3!)", "0.16666666"));
         // Note that we have a Result.INACCURATE version of this test as well
         assertEquals(AnswerChecker.Result.CORRECT, AnswerChecker.checkAnswer("1/3", "0.33333333333333"));
         assertEquals(AnswerChecker.Result.CORRECT, AnswerChecker.checkAnswer("C(5, 3)", "10"));
@@ -33,5 +34,8 @@ public class AnswerCheckerTest {
         assertEquals(AnswerChecker.Result.INVALID, AnswerChecker.checkAnswer("1", ""));
         // Imbalanced parentheses
         assertEquals(AnswerChecker.Result.INVALID, AnswerChecker.checkAnswer("( 1 + 5", ""));
+        // Undefined, should be invalid
+        assertEquals(AnswerChecker.Result.INVALID, AnswerChecker.checkAnswer("1", "0/0"));
+        assertEquals(AnswerChecker.Result.INVALID, AnswerChecker.checkAnswer("1", "hello world, this is not math"));
     }
 }


### PR DESCRIPTION
This commit introduces a new feature that allows users to get hints for puzzles by launching the Gemini app.

- A "Talk to Gemini" button has been added to the puzzle screen.
- When clicked, the puzzle text is copied to the clipboard, and an Intent is fired to open the Gemini app.
- If the Gemini app is not installed, the user is redirected to the Play Store.
- The minimum SDK version has been increased to 19 to support the new testing libraries.
- An end-to-end test has been added to verify the new functionality.

This is a simple option for https://github.com/atorch/probability_puzzles/issues/34